### PR TITLE
Implement terminal layout and blog route migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ pnpm-debug.log*
 
 # environment variables
 .env
+.env.local
+.env.*.local
+.envrc
 .env.production
 
 # macOS-specific files

--- a/src/components/Terminal.astro
+++ b/src/components/Terminal.astro
@@ -1,0 +1,101 @@
+---
+interface Props {
+  path?: string;
+  status?: string;
+}
+
+const { path = '~', status = 'READY' } = Astro.props;
+---
+
+<section class="terminal-shell" aria-label="Terminal shell">
+  <header class="terminal-titlebar">
+    <div class="terminal-dots" aria-hidden="true">
+      <span class="dot dot-red"></span>
+      <span class="dot dot-yellow"></span>
+      <span class="dot dot-green"></span>
+    </div>
+    <p class="terminal-title">pasha@portfolio:{path}</p>
+  </header>
+
+  <div class="terminal-content">
+    <slot />
+  </div>
+
+  <footer class="terminal-statusbar">
+    <p class="status-left">{path}</p>
+    <p class="status-right">{status}</p>
+  </footer>
+</section>
+
+<style>
+  .terminal-shell {
+    width: 100%;
+    border: 1px solid rgba(97, 175, 239, 0.35);
+    border-radius: 12px;
+    overflow: hidden;
+    background: rgba(10, 14, 20, 0.82);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(8px);
+  }
+
+  .terminal-titlebar,
+  .terminal-statusbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 16px;
+    font-size: 0.8rem;
+    color: var(--term-dim);
+    background: rgba(0, 0, 0, 0.25);
+  }
+
+  .terminal-titlebar {
+    border-bottom: 1px solid rgba(97, 175, 239, 0.2);
+  }
+
+  .terminal-statusbar {
+    border-top: 1px solid rgba(97, 175, 239, 0.2);
+  }
+
+  .terminal-title,
+  .status-left,
+  .status-right {
+    margin: 0;
+  }
+
+  .terminal-dots {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+  }
+
+  .dot-red {
+    background: var(--term-red);
+  }
+
+  .dot-yellow {
+    background: var(--term-yellow);
+  }
+
+  .dot-green {
+    background: var(--term-green-dot);
+  }
+
+  .terminal-content {
+    padding: 24px 16px;
+    overflow-x: auto;
+  }
+
+  @media (min-width: 768px) {
+    .terminal-content {
+      padding: 28px 24px;
+    }
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,28 +1,21 @@
 ---
-//src/layouts/BaseLayout.astro
 const { title = 'Personal Card Astro', description } = Astro.props;
-
 import '../styles/global.css';
 ---
-<!-- Here you can change everything related to the head, favicon, icons, and fonts. -->
 
 <html lang="en">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content={description}>
-    <!-- FAVICON -->
-    <link rel="shortcut icon" href="..//favicon.ico" type="image/x-icon">
-    <!-- GOOGLE FONTS -->
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400&display=swap" rel="stylesheet">
-    <!-- CDN ICON BOOTSTRAP 5 -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
     <title>{title}</title>
   </head>
   <body>
-    <main>
+    <main class="terminal-page">
       <slot />
     </main>
   </body>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,13 +1,15 @@
 ---
 import BaseLayout from './BaseLayout.astro';
+import Terminal from '../components/Terminal.astro';
 const { frontmatter } = Astro.props;
 ---
 
-<BaseLayout title={frontmatter.title}>
-  <article class="max-w-3xl mx-auto px-4 py-8">
-    <header class="mb-8">
-      <h1 class="text-4xl font-bold mb-4 text-gray-900">{frontmatter.title}</h1>
-      <div class="text-gray-600">
+<BaseLayout title={`${frontmatter.title} | Blog`}>
+  <Terminal path="~/blog/post" status="READING">
+    <header class="post-meta">
+      <p><span class="prompt">pasha@portfolio:~/blog$</span> cat {frontmatter.title.toLowerCase().replaceAll(' ', '-')}.md</p>
+      <h1>{frontmatter.title}</h1>
+      <p class="meta-line">
         <time datetime={frontmatter.pubDate.toISOString()}>
           {frontmatter.pubDate.toLocaleDateString('en-US', {
             year: 'numeric',
@@ -15,26 +17,39 @@ const { frontmatter } = Astro.props;
             day: 'numeric'
           })}
         </time>
-        {frontmatter.tags && (
-          <div class="mt-2">
-            {frontmatter.tags.map(tag => (
-              <span class="inline-block bg-gray-100 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">
-                {tag}
-              </span>
-            ))}
-          </div>
+        {frontmatter.tags && frontmatter.tags.length > 0 && (
+          <span> | {frontmatter.tags.join(', ')}</span>
         )}
-      </div>
+      </p>
+      <p class="back"><a href="/blog">cd .. (back to blog)</a></p>
     </header>
-    {frontmatter.heroImage && (
-      <img
-        src={frontmatter.heroImage}
-        alt={frontmatter.title}
-        class="w-full h-64 object-cover rounded-lg mb-8 shadow-lg"
-      />
-    )}
-    <div class="prose prose-lg max-w-none prose-headings:text-gray-900 prose-p:text-gray-700 prose-a:text-blue-600 hover:prose-a:text-blue-800">
+    <div class="prose prose-invert prose-pre:bg-transparent prose-code:text-[inherit] max-w-none">
       <slot />
     </div>
-  </article>
+  </Terminal>
 </BaseLayout> 
+
+<style>
+  .prompt {
+    color: var(--term-green);
+  }
+
+  .post-meta h1 {
+    margin: 8px 0 6px;
+    font-size: 1.65rem;
+    line-height: 1.2;
+  }
+
+  .post-meta p {
+    margin: 0;
+  }
+
+  .meta-line {
+    color: var(--term-dim);
+    margin-bottom: 8px;
+  }
+
+  .back {
+    margin-bottom: 16px;
+  }
+</style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,25 @@
+---
+import { getCollection, getEntryBySlug } from 'astro:content';
+import BlogPost from '../../layouts/BlogPost.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { slug: post.slug },
+  }));
+}
+
+const { slug } = Astro.props;
+const post = await getEntryBySlug('blog', slug);
+
+if (!post) {
+  throw new Error(`Blog post not found for slug: ${slug}`);
+}
+
+const { Content } = await post.render();
+---
+
+<BlogPost frontmatter={post.data}>
+  <Content />
+</BlogPost>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,52 +1,66 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Terminal from '../../components/Terminal.astro';
 import { getCollection } from 'astro:content';
 
 const posts = await getCollection('blog');
 const sortedPosts = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 ---
 
-<BaseLayout title="Blog">
-  <div class="max-w-4xl mx-auto px-4 py-8">
-    <h1 class="text-4xl font-bold mb-8 text-gray-900">Blog</h1>
-    <div class="grid gap-8">
-      {sortedPosts.map(post => (
-        <article class="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300">
-          {post.data.heroImage && (
-            <img
-              src={post.data.heroImage}
-              alt={post.data.title}
-              class="w-full h-48 object-cover"
-            />
-          )}
-          <div class="p-6">
-            <h2 class="text-2xl font-bold mb-2">
-              <a href={`/blog/${post.slug}`} class="text-gray-900 hover:text-blue-600 transition-colors">
-                {post.data.title}
-              </a>
-            </h2>
-            <p class="text-gray-600 mb-4">{post.data.description}</p>
-            <div class="flex items-center justify-between">
-              <time datetime={post.data.pubDate.toISOString()} class="text-sm text-gray-500">
-                {post.data.pubDate.toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric'
-                })}
-              </time>
-              {post.data.tags && (
-                <div class="flex gap-2">
-                  {post.data.tags.map(tag => (
-                    <span class="text-sm bg-gray-100 text-gray-700 px-2 py-1 rounded">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        </article>
-      ))}
+<BaseLayout title="Blog | Pasha Fateev">
+  <Terminal path="~/blog" status={`POSTS ${sortedPosts.length}`}>
+    <div class="output">
+      <p><span class="prompt">pasha@portfolio:~/blog$</span> ls -la</p>
+      <ul class="post-list">
+        {sortedPosts.map((post) => (
+          <li>
+            <time datetime={post.data.pubDate.toISOString()}>
+              {post.data.pubDate.toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: '2-digit',
+              })}
+            </time>
+            <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+          </li>
+        ))}
+      </ul>
+      <p><span class="prompt">pasha@portfolio:~/blog$</span> cd ..</p>
+      <p><a href="/">back to home</a><span class="cursor"></span></p>
     </div>
-  </div>
-</BaseLayout> 
+  </Terminal>
+</BaseLayout>
+
+<style>
+  .output {
+    display: grid;
+    gap: 12px;
+  }
+
+  .output p {
+    margin: 0;
+  }
+
+  .prompt {
+    color: var(--term-green);
+  }
+
+  .post-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 8px;
+  }
+
+  .post-list li {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .post-list time {
+    color: var(--term-dim);
+    min-width: 112px;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,22 +1,59 @@
 ---
-// src/pages/index.astro
-
 import BaseLayout from "../layouts/BaseLayout.astro";
-import Card from "../components/Card.astro";
+import Terminal from "../components/Terminal.astro";
 ---
 
 <BaseLayout
   title="Pasha Fateev | Software Engineer"
   description="Software Engineer with a musical background, working with Python and Go. Former UW CS grad bringing creativity to code."
 >
-  <Card
-    name="Pasha Fateev"
-    position="Software Engineer"
-    aboutMe={`Hi, I'm Pasha — a backend engineer who enjoys writing production-quality code and solving real-world problems. At AutoKitteh, I built event-driven workflows in Python and integrations in Go for third-party platforms, including a bidirectional sync between Linear and an enterprise app using OAuth and gRPC. I've worked with APIs from GitHub, AWS, Slack, Google, Discord, and OpenAI, and contributed upstream to PyGithub. I'm especially interested in backend engineering, developer experience, and learning more about distributed systems.`}
-    linkedin="https://www.linkedin.com/in/pashafateev/"
-    github="https://github.com/pashafateev"
-    blog="/blog"
-    cvLink="/files/resume-cv.pdf"
-    profileImage="/images/profile.webp"
-  />
+  <Terminal path="~" status="HOME">
+    <div class="output">
+      <p><span class="prompt">pasha@portfolio:~$</span> whoami</p>
+      <p class="value">Pasha Fateev - Software Engineer</p>
+
+      <p><span class="prompt">pasha@portfolio:~$</span> cat about.txt</p>
+      <p class="value">
+        Backend engineer focused on Python and Go, building event-driven systems and durable integrations.
+        I care about clear APIs, reliable automation, and practical developer experience.
+      </p>
+
+      <p><span class="prompt">pasha@portfolio:~$</span> ls links/</p>
+      <ul class="links">
+        <li><a href="https://github.com/pashafateev" target="_blank" rel="noreferrer">github</a></li>
+        <li><a href="https://www.linkedin.com/in/pashafateev/" target="_blank" rel="noreferrer">linkedin</a></li>
+        <li><a href="/blog">blog</a></li>
+        <li><a href="/files/resume-cv.pdf" target="_blank" rel="noreferrer">resume.pdf</a></li>
+      </ul>
+
+      <p><span class="prompt">pasha@portfolio:~$</span> help</p>
+      <p class="value">Open links above or navigate to <a href="/blog">/blog</a> to read posts.<span class="cursor"></span></p>
+    </div>
+  </Terminal>
 </BaseLayout>
+
+<style>
+  .output {
+    display: grid;
+    gap: 12px;
+  }
+
+  .output p {
+    margin: 0;
+  }
+
+  .prompt {
+    color: var(--term-green);
+  }
+
+  .value {
+    color: var(--term-fg);
+  }
+
+  .links {
+    margin: 0;
+    padding-left: 20px;
+    display: grid;
+    gap: 4px;
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,80 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --term-bg: #0a0e14;
+  --term-fg: #c5c8c6;
+  --term-green: #39ff14;
+  --term-dim: #5c6370;
+  --term-blue: #61afef;
+  --term-red: #ff5f56;
+  --term-yellow: #ffbd2e;
+  --term-green-dot: #27c93f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 16px;
+  color: var(--term-fg);
+  background:
+    radial-gradient(circle at 20% 0%, rgba(97, 175, 239, 0.1), transparent 35%),
+    radial-gradient(circle at 80% 100%, rgba(57, 255, 20, 0.08), transparent 35%),
+    var(--term-bg);
+  line-height: 1.5;
+}
+
+a {
+  color: var(--term-blue);
+}
+
+a:hover {
+  color: var(--term-green);
+}
+
+.terminal-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px 16px;
+}
+
+.cursor {
+  display: inline-block;
+  width: 9px;
+  height: 1em;
+  margin-left: 3px;
+  vertical-align: text-bottom;
+  background: var(--term-green);
+  animation: cursor-blink 1s step-end infinite;
+}
+
+@keyframes cursor-blink {
+  0%, 49% {
+    opacity: 1;
+  }
+
+  50%, 100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -2,9 +2,39 @@
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+      },
+      colors: {
+        term: {
+          bg: 'var(--term-bg)',
+          fg: 'var(--term-fg)',
+          green: 'var(--term-green)',
+          dim: 'var(--term-dim)',
+          blue: 'var(--term-blue)',
+          red: 'var(--term-red)',
+          yellow: 'var(--term-yellow)',
+          dotgreen: 'var(--term-green-dot)',
+        },
+      },
+      animation: {
+        'cursor-blink': 'cursor-blink 1s step-end infinite',
+        'terminal-glow': 'terminal-glow 2s ease-in-out infinite alternate',
+      },
+      keyframes: {
+        'cursor-blink': {
+          '0%, 49%': { opacity: '1' },
+          '50%, 100%': { opacity: '0' },
+        },
+        'terminal-glow': {
+          from: { boxShadow: '0 0 0 rgba(57, 255, 20, 0)' },
+          to: { boxShadow: '0 0 20px rgba(57, 255, 20, 0.08)' },
+        },
+      },
+    },
   },
   plugins: [
     require('@tailwindcss/typography'),
   ],
-} 
+}


### PR DESCRIPTION
## Summary
- add terminal theme tokens, shared styles, and a reusable Terminal shell component
- migrate home and blog index pages to terminal-style static output
- add blog slug route and terminal-themed blog post layout
- keep resume and external links working in no-JS navigation

## Validation
- npm run build