### PR TITLE
content: replace first blog post with explicit AI placeholder

### DIFF
--- a/src/content/blog/welcome.md
+++ b/src/content/blog/welcome.md
@@ -1,21 +1,13 @@
 ---
-title: "Welcome to My Blog"
-description: "This is my first blog post where I share my thoughts and experiences."
-pubDate: 2024-03-20
-tags: ["welcome", "first-post"]
+title: "Boot Message"
+description: "AI-written starter post to keep the blog alive until real notes land."
+pubDate: 2026-02-16
+tags: ["meta", "ai", "placeholder"]
 ---
 
-# Welcome to My Blog
+This first post was written by AI, not by Pasha.
 
-This is my first blog post! I'm excited to share my thoughts, experiences, and knowledge with you.
+It exists so `/blog` does not look abandoned while the real writing queue warms up.
+The plan is simple: short field notes, candid takes, minimal editing, shipped fast.
 
-## What to Expect
-
-In this blog, I'll be sharing:
-
-- Technical insights
-- Personal experiences
-- Project updates
-- And much more!
-
-Feel free to explore and stay tuned for more content. 
+If you're reading this later, this file should be gone or buried under actual posts.


### PR DESCRIPTION
## Summary
- replace the initial blog seed post with a short, on-brand placeholder
- clearly state that the post was written by AI and is not authored by Pasha
- keep tone aligned with the terminal/candid style and set expectation for future unedited notes

## Verification
- `npm run build`
- Result: build succeeded; 3 pages generated (`/`, `/blog`, `/blog/welcome`)
