### PR TITLE
feat: add one-command blog post flow with auto PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Edit `src/pages/index.astro` for:
 
 - Add posts under `src/content/blog/*.md`
 - Frontmatter schema is defined in `src/content/config.ts`
+- Quick flow (branch + commit + push + PR): `npm run post:new -- "Post Title" "Description" "tag1,tag2"`
 
 Required frontmatter:
 - `title`
@@ -117,6 +118,7 @@ Optional frontmatter:
 - `npm run build` - build site to `dist/`
 - `npm run preview` - preview production build
 - `npm run astro` - run Astro CLI commands
+- `npm run post:new -- "Post Title" "Description" "tag1,tag2"` - create blog post file, branch, commit, push, and PR
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "post:new": "bash ./scripts/new-post.sh"
   },
   "dependencies": {
     "astro": "^4.9.1"

--- a/scripts/new-post.sh
+++ b/scripts/new-post.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  npm run post:new -- "Post Title" ["Post description"] ["tag1,tag2"]
+
+Examples:
+  npm run post:new -- "Shipping Beats Perfection"
+  npm run post:new -- "Friday Notes" "Quick update on this week's progress" "notes,weekly"
+USAGE
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: run this inside the git repo."
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Error: working tree is not clean. Commit/stash changes before creating a post."
+  exit 1
+fi
+
+title="$1"
+description="${2:-Quick placeholder description. Replace with your real summary.}"
+tags_csv="${3:-notes}"
+pub_date="$(date -u +%F)"
+
+slug="$(printf '%s' "$title" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')"
+if [ -z "$slug" ]; then
+  slug="post-$(date -u +%s)"
+fi
+
+branch="content/post-${slug}"
+file="src/content/blog/${pub_date}-${slug}.md"
+
+if [ -e "$file" ]; then
+  echo "Error: post file already exists: $file"
+  exit 1
+fi
+
+git switch -c "$branch"
+
+declare -a tag_items=()
+IFS=',' read -r -a raw_tags <<< "$tags_csv"
+for raw_tag in "${raw_tags[@]}"; do
+  trimmed="$(printf '%s' "$raw_tag" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+  if [ -n "$trimmed" ]; then
+    tag_items+=("\"$trimmed\"")
+  fi
+done
+
+if [ "${#tag_items[@]}" -eq 0 ]; then
+  tag_items+=("\"notes\"")
+fi
+
+tags_joined="$(IFS=', '; echo "${tag_items[*]}")"
+
+cat > "$file" <<POST
+---
+title: "$title"
+description: "$description"
+pubDate: $pub_date
+tags: [$tags_joined]
+---
+
+This post was created with the quick-post script.
+
+Write your candid notes here.
+POST
+
+git add "$file"
+git commit -m "Add blog post: $title"
+git push -u origin "$branch"
+
+if command -v gh >/dev/null 2>&1; then
+  pr_body_file="$(mktemp)"
+  cat > "$pr_body_file" <<PR
+## Summary
+- add new blog post: $title
+- file: $file
+
+## Verification
+- npm run build
+PR
+
+  gh pr create \
+    --base main \
+    --head "$branch" \
+    --title "content: add post '$title'" \
+    --body-file "$pr_body_file"
+
+  rm -f "$pr_body_file"
+else
+  echo "gh CLI not found; create PR manually:"
+  echo "https://github.com/$(git config --get remote.origin.url | sed -E 's#(git@github.com:|https://github.com/)##; s/\.git$//')/compare/main...${branch}?expand=1"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/new-post.sh` to automate blog post creation end-to-end:
  - create post file in `src/content/blog`
  - create branch (`content/post-<slug>`)
  - commit and push
  - create PR via `gh`
- add npm script `post:new` in `package.json`
- document quick-post usage in `README.md`

## Usage
- `npm run post:new -- "Post Title" "Post description" "tag1,tag2"`

## Verification
- `bash -n scripts/new-post.sh`
- `bash scripts/new-post.sh --help`
- `npm run build`
- Result: build succeeded; 3 pages generated (`/`, `/blog`, `/blog/welcome`)
