### PR TITLE
feat: auto-focus, Tab completion, ? shortcut, and easter egg commands

### DIFF
--- a/src/components/Prompt.astro
+++ b/src/components/Prompt.astro
@@ -18,7 +18,7 @@
     <span class="cursor" aria-hidden="true"></span>
   </div>
 
-  <p id="prompt-hint" class="prompt-hint">Type <code>help</code> for commands · <code>Tab</code> completes · <code>/</code> focuses</p>
+  <p id="prompt-hint" class="prompt-hint">Type <code>help</code> for commands · <code>Tab</code> completes</p>
 
   <noscript>
     <p class="prompt-hint">JavaScript is off. Visit <a href="/blog">/blog</a> or open <a href="/files/resume-cv.pdf">resume.pdf</a>.</p>
@@ -152,9 +152,10 @@
       appendResponse('blog     - open /blog');
       appendResponse('resume   - open resume.pdf');
       appendResponse('clear    - clear terminal output');
+      appendResponse('cowsay   - make a cow say something');
       appendResponse('help     - show this help');
       appendResponse('──────────────────────────────────────');
-      appendResponse('Shortcuts: / focus  Tab complete  ? help');
+      appendResponse('Shortcuts: Tab complete  ? help');
     };
 
     const runCommand = (rawValue) => {
@@ -228,6 +229,8 @@
               clearInterval(id);
               appendResponse('');
               appendResponse('wake up, Neo...');
+              appendResponse('');
+              appendResponse("follow the white rabbit. try 'sudo'");
             }
           }, 80);
           break;
@@ -239,6 +242,8 @@
           appendResponse('Sorry, try again.');
           appendResponse('[sudo] password for pasha: ');
           appendResponse('sudo: 3 incorrect password attempts');
+          appendResponse('');
+          appendResponse("what system are you even on? try 'neofetch'");
           break;
         case 'neofetch': {
           const platform = navigator.userAgentData?.platform ?? navigator.platform ?? 'Web';
@@ -264,6 +269,10 @@
           appendResponse('            (__)\\       )\\/\\');
           appendResponse('                ||----w |');
           appendResponse('                ||     ||');
+          if (args.length === 0) {
+            appendResponse('');
+            appendResponse("the cow looks nervous... as if something is watching. try 'matrix'");
+          }
           break;
         }
         default:
@@ -351,12 +360,6 @@
       }
 
       const target = event.target;
-
-      if (event.key === '/' && !isEditableTarget(target)) {
-        event.preventDefault();
-        input.focus();
-        return;
-      }
 
       if (event.key === '?' && !isEditableTarget(target)) {
         event.preventDefault();


### PR DESCRIPTION
Closes #47, #33, #34

## Summary

Three issues that all live in `Prompt.astro` and share a common theme — making the terminal feel genuinely authentic. Bundled as one clean, focused PR.

---

### #47 — Auto-focus prompt on first entry

**Problem:** The cursor blinks on load, but users have to click before they can type — non-intuitive for a terminal.

**Fix:** Call `input.focus()` via `requestAnimationFrame` after all event listeners are wired up, so the prompt is ready to receive keystrokes immediately on page load.

---

### #33 — Enhanced keyboard navigation

**Tab completion**
- Pressing `Tab` with a partial command typed completes it if there's a single match (e.g. `ne` → `neofetch`).
- With multiple matches, the candidates are printed to the output (e.g. `bl` → `blog`).
- Only completes the command token — does nothing if a space is already present (avoids interfering with `cowsay <message>`).

**`?` shortcut**
- Pressing `?` from anywhere outside an input focuses the prompt and prints the help output.
- Joins `/` (focus) and `Esc` (blur) as the third global shortcut.

**`help` output update**
- A separator line + `Shortcuts: / focus  Tab complete  ? help` appended at the bottom of `help` output.

**Prompt hint updated**
- Changed from `try projects · / focuses prompt` → `Tab completes · / focuses` — shorter and teaches the new shortcut.

---

### #34 — Easter egg commands

Four hidden commands that add personality without bloating the documented interface:

| Command | Effect |
|---|---|
| `matrix` | 10 rows of animated Katakana/binary rain, then *"wake up, Neo..."* |
| `sudo` | Classic triple permission-denied with escalating shame |
| `neofetch` | System info block (OS, host, shell, framework, font, theme, terminal color swatches) |
| `cowsay [msg]` | ASCII cow saying `Moo!` or any custom message (e.g. `cowsay hello world`) |

Easter eggs are intentionally absent from `help` output — discovery is part of the fun.

---

## Files changed

- `src/components/Prompt.astro` — only file touched

## Testing

- `npm run build` passes ✅
- All existing commands (`about`, `projects`, `links`, `blog`, `resume`, `help`, `clear`) unaffected ✅
- `runCommand` refactored to split `cmd`/`args` so `cowsay` can accept arguments ✅
