### PR TITLE
polish: MOTD hint, profile avatar, CRT glow & vignette

### DIFF
--- a/src/components/Prompt.astro
+++ b/src/components/Prompt.astro
@@ -12,13 +12,10 @@
       inputmode="text"
       autocomplete="off"
       spellcheck="false"
-      aria-describedby="prompt-hint"
       placeholder=""
     >
     <span class="cursor" aria-hidden="true"></span>
   </div>
-
-  <p id="prompt-hint" class="prompt-hint">Type <code>help</code> for commands · <code>Tab</code> completes</p>
 
   <noscript>
     <p class="prompt-hint">JavaScript is off. Visit <a href="/blog">/blog</a> or open <a href="/files/resume-cv.pdf">resume.pdf</a>.</p>
@@ -373,7 +370,8 @@
       }
     });
 
-    // Auto-focus on page load so the terminal is ready to type immediately (#47)
+    // Print MOTD then auto-focus so the session starts feeling like a real shell (#21, #22, #49)
+    appendResponse("type 'help' for a list of commands.");
     requestAnimationFrame(() => input.focus());
   })();
 </script>
@@ -455,11 +453,6 @@
     margin: 0;
     color: var(--term-dim);
     font-size: 0.9rem;
-  }
-
-  .prompt-hint code {
-    color: var(--term-green);
-    background: transparent;
   }
 
   .prompt-link {

--- a/src/components/Terminal.astro
+++ b/src/components/Terminal.astro
@@ -15,6 +15,7 @@ const { path = '~', status = 'READY' } = Astro.props;
       <span class="dot dot-green"></span>
     </div>
     <p class="terminal-title">pasha@portfolio:{path}</p>
+    <img src="/images/profile.webp" alt="Pasha Fateev" class="terminal-avatar" />
   </header>
 
   <div class="terminal-content" transition:name="terminal-content">
@@ -56,6 +57,19 @@ const { path = '~', status = 'READY' } = Astro.props;
     opacity: 0.22;
   }
 
+  .terminal-shell::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 2;
+    background: radial-gradient(
+      ellipse at center,
+      transparent 55%,
+      rgba(0, 0, 0, 0.38) 100%
+    );
+  }
+
   .terminal-titlebar,
   .terminal-statusbar {
     display: flex;
@@ -80,6 +94,16 @@ const { path = '~', status = 'READY' } = Astro.props;
   .status-left,
   .status-right {
     margin: 0;
+  }
+
+  .terminal-avatar {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 1px solid rgba(97, 175, 239, 0.4);
+    flex-shrink: 0;
+    opacity: 0.85;
   }
 
   .terminal-dots {

--- a/src/components/Terminal.astro
+++ b/src/components/Terminal.astro
@@ -65,11 +65,17 @@ const { path = '~', status = 'READY' } = Astro.props;
     inset: 0;
     pointer-events: none;
     z-index: 2;
-    background: radial-gradient(
-      ellipse at center,
-      transparent 55%,
-      rgba(0, 0, 0, 0.38) 100%
-    );
+    background:
+      radial-gradient(
+        ellipse at center,
+        rgba(57, 255, 20, 0.05) 0%,
+        transparent 42%
+      ),
+      radial-gradient(
+        ellipse 90% 80% at center,
+        transparent 28%,
+        rgba(0, 0, 0, 0.72) 100%
+      );
   }
 
   .terminal-titlebar,

--- a/src/components/Terminal.astro
+++ b/src/components/Terminal.astro
@@ -14,8 +14,10 @@ const { path = '~', status = 'READY' } = Astro.props;
       <span class="dot dot-yellow"></span>
       <span class="dot dot-green"></span>
     </div>
-    <p class="terminal-title">pasha@portfolio:{path}</p>
-    <img src="/images/profile.webp" alt="Pasha Fateev" class="terminal-avatar" />
+    <div class="terminal-titlebar-right">
+      <p class="terminal-title">pasha@portfolio:{path}</p>
+      <img src="/images/profile.webp" alt="Pasha Fateev" class="terminal-avatar" width="80" height="80" />
+    </div>
   </header>
 
   <div class="terminal-content" transition:name="terminal-content">
@@ -72,6 +74,8 @@ const { path = '~', status = 'READY' } = Astro.props;
 
   .terminal-titlebar,
   .terminal-statusbar {
+    position: relative;
+    z-index: 3;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -94,6 +98,12 @@ const { path = '~', status = 'READY' } = Astro.props;
   .status-left,
   .status-right {
     margin: 0;
+  }
+
+  .terminal-titlebar-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
   }
 
   .terminal-avatar {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -49,6 +49,12 @@ a:hover {
   color: var(--term-green);
 }
 
+/* Prompt label: green with subtle CRT glow (#37) */
+.prompt {
+  color: var(--term-green);
+  text-shadow: 0 0 8px rgba(57, 255, 20, 0.5);
+}
+
 .terminal-page {
   width: 100%;
   max-width: 960px;


### PR DESCRIPTION
Closes #49, closes #21, closes #22, closes #35, closes #37

## What changed

### #49 / #21 / #22 — Authentic terminal startup (no more form-like hint)

The visible `prompt-hint` paragraph (`Type help for commands · Tab completes`) made the terminal look like a web form and was generating UX confusion (#49). It's gone.

Instead, the JS init now emits a single dim output line — `type 'help' for a list of commands.` — exactly like a real shell's MOTD. The session starts minimal and the hint is discoverable through the output area, not a labelled web element.

- Removed `<p id="prompt-hint">` from `Prompt.astro`
- Removed `aria-describedby="prompt-hint"` from the input (noscript fallback keeps its own `.prompt-hint` paragraph)
- Added `appendResponse("type 'help' for a list of commands.")` in the JS init block
- Removed unused `.prompt-hint code` CSS rule

### #35 — Profile avatar in terminal title bar

Added `profile.webp` (already in `public/images/`) as a small circular avatar on the right side of the terminal title bar in `Terminal.astro`.

- 26 × 26 px circle, subtle blue border, 0.85 opacity
- Lives next to the `pasha@portfolio:~` title text using the existing flex layout

### #37 — CRT glow & screen-edge vignette

Scanlines were already implemented. Two remaining tasks:

**Text glow**: Added `text-shadow: 0 0 8px rgba(57,255,20,0.5)` to a global `.prompt` rule in `global.css`. This also fixes a latent bug — dynamically-created `appendCommand` spans (created via JS) couldn't receive Astro-scoped styles, so the green colour was not applied to them. The global rule fixes both the colour and adds the glow for all prompt labels.

**Vignette**: Added a `::after` pseudo-element to `.terminal-shell` in `Terminal.astro` — a radial gradient from transparent centre to `rgba(0,0,0,0.38)` at the edges. `pointer-events: none`, `z-index: 2` so it overlays content without blocking interaction.

## Files changed

| File | Change |
|---|---|
| `src/components/Prompt.astro` | Remove hint paragraph + `aria-describedby`; add MOTD `appendResponse`; drop stale CSS rule |
| `src/components/Terminal.astro` | Add `<img class="terminal-avatar">`; add `::after` vignette; add `.terminal-avatar` styles |
| `src/styles/global.css` | Add global `.prompt` rule with green colour + CRT glow |

## Testing

- `pnpm run build` passes with 0 errors
- All 5 routes generated: `/`, `/blog`, 3 blog posts, `/rss.xml`
