### PR TITLE
feat: blog tags display and client-side search (#38, #39)

### DIFF
--- a/src/content/blog/building-mycel.md
+++ b/src/content/blog/building-mycel.md
@@ -2,6 +2,7 @@
 title: "Using OpenClaw to Build a Better OpenClaw"
 description: "Why I'm building a personal AI assistant from scratch."
 pubDate: 2026-02-20
+tags: ["ai", "projects", "mycel"]
 ---
 
 My first impression of OpenClaw was that of being completely blown away and obsessed with using it. I also noticed a lot of frustrations right out of the gate.

--- a/src/content/blog/one-in-the-morning.md
+++ b/src/content/blog/one-in-the-morning.md
@@ -2,6 +2,7 @@
 title: "One in the Morning"
 description: "A first dictated note on AI, fear, and excitement."
 pubDate: 2026-02-16
+tags: ["ai", "thoughts"]
 ---
 
 It’s one in the morning, and just for context, I do not usually, or at least try not to, stay up after about 10:30. This is the second night

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -13,7 +13,7 @@ const { frontmatter } = Astro.props;
   <header class="post-meta">
     <p><span class="prompt">pasha@portfolio:~/blog$</span> cat {frontmatter.title.toLowerCase().replaceAll(' ', '-')}.md</p>
     <h1>{frontmatter.title}</h1>
-    <p class="meta-line">
+    <div class="meta-line">
       <time datetime={frontmatter.pubDate.toISOString()}>
         {frontmatter.pubDate.toLocaleDateString('en-US', {
           year: 'numeric',
@@ -22,9 +22,13 @@ const { frontmatter } = Astro.props;
         })}
       </time>
       {frontmatter.tags && frontmatter.tags.length > 0 && (
-        <span> | {frontmatter.tags.join(', ')}</span>
+        <div class="post-tags" aria-label="Tags">
+          {frontmatter.tags.map((tag: string) => (
+            <a href={`/blog?tag=${encodeURIComponent(tag)}`} class="tag-chip">#{tag}</a>
+          ))}
+        </div>
       )}
-    </p>
+    </div>
     <p class="back"><a href="/blog">cd .. (back to blog)</a></p>
   </header>
   <div class="prose prose-invert prose-pre:bg-transparent max-w-none">
@@ -50,6 +54,35 @@ const { frontmatter } = Astro.props;
   .meta-line {
     color: var(--term-dim);
     margin-bottom: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+
+  .tag-chip {
+    background: transparent;
+    border: 1px solid rgba(97, 175, 239, 0.3);
+    border-radius: 4px;
+    color: var(--term-dim);
+    font: inherit;
+    font-size: 0.78rem;
+    line-height: 1;
+    padding: 3px 7px;
+    text-decoration: none;
+    transition: border-color 120ms, color 120ms;
+  }
+
+  .tag-chip:hover,
+  .tag-chip:focus-visible {
+    border-color: var(--term-blue);
+    color: var(--term-blue);
   }
 
   .back {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -22,7 +22,7 @@ const { frontmatter } = Astro.props;
         })}
       </time>
       {frontmatter.tags && frontmatter.tags.length > 0 && (
-        <div class="post-tags" aria-label="Tags">
+        <div class="post-tags" role="group" aria-label="Tags">
           {frontmatter.tags.map((tag: string) => (
             <a href={`/blog?tag=${encodeURIComponent(tag)}`} class="tag-chip">#{tag}</a>
           ))}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,29 +4,148 @@ import { getCollection } from 'astro:content';
 
 const posts = await getCollection('blog');
 const sortedPosts = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+// Collect all unique tags across posts for the filter bar
+const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort();
+
+// Serialise post data for client-side search/filter
+const postData = sortedPosts.map((post) => ({
+  slug: post.slug,
+  title: post.data.title,
+  description: post.data.description,
+  tags: post.data.tags ?? [],
+  date: post.data.pubDate.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  }),
+  dateIso: post.data.pubDate.toISOString(),
+}));
 ---
 
 <BaseLayout title="Blog | Pasha Fateev" path="~/blog" status={`POSTS ${sortedPosts.length}`}>
   <div class="output">
     <p><span class="prompt">pasha@portfolio:~/blog$</span> ls -la</p>
-    <ul class="post-list">
+
+    <!-- search & tag filters -->
+    <div class="controls" id="blog-controls">
+      <div class="search-row">
+        <label for="blog-search" class="sr-only">Search posts</label>
+        <input
+          id="blog-search"
+          class="search-input"
+          type="search"
+          placeholder="grep -r ..."
+          autocomplete="off"
+          spellcheck="false"
+        />
+      </div>
+      {allTags.length > 0 && (
+        <div class="tag-bar" id="tag-bar" aria-label="Filter by tag">
+          {allTags.map((tag) => (
+            <button class="tag-btn" data-tag={tag} type="button">#{tag}</button>
+          ))}
+        </div>
+      )}
+    </div>
+
+    <ul class="post-list" id="post-list" data-posts={JSON.stringify(postData)}>
       {sortedPosts.map((post) => (
-        <li>
-          <time datetime={post.data.pubDate.toISOString()}>
-            {post.data.pubDate.toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'short',
-              day: '2-digit',
-            })}
-          </time>
-          <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+        <li data-title={post.data.title.toLowerCase()} data-desc={post.data.description.toLowerCase()} data-tags={(post.data.tags ?? []).join(',')}>
+          <div class="post-row">
+            <time datetime={post.data.pubDate.toISOString()}>
+              {post.data.pubDate.toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: '2-digit',
+              })}
+            </time>
+            <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+          </div>
+          {post.data.tags && post.data.tags.length > 0 && (
+            <div class="post-tags" aria-label="Tags">
+              {post.data.tags.map((tag) => (
+                <button class="tag-chip" data-tag={tag} type="button">#{tag}</button>
+              ))}
+            </div>
+          )}
         </li>
       ))}
     </ul>
+
+    <p class="no-results" id="no-results" hidden>No posts match your search.</p>
+
     <p><span class="prompt">pasha@portfolio:~/blog$</span> cd ..</p>
     <p><a href="/">back to home</a><span class="cursor"></span></p>
   </div>
 </BaseLayout>
+
+<script is:inline>
+  (() => {
+    const searchInput = document.getElementById('blog-search');
+    const postList = document.getElementById('post-list');
+    const noResults = document.getElementById('no-results');
+    const tagBar = document.getElementById('tag-bar');
+
+    if (!searchInput || !postList) return;
+
+    const items = Array.from(postList.querySelectorAll('li'));
+    let activeTag = null;
+
+    const applyFilters = () => {
+      const query = searchInput.value.trim().toLowerCase();
+      let visibleCount = 0;
+
+      items.forEach((li) => {
+        const title = li.dataset.title || '';
+        const desc = li.dataset.desc || '';
+        const tags = li.dataset.tags ? li.dataset.tags.split(',') : [];
+
+        const matchesSearch = !query || title.includes(query) || desc.includes(query);
+        const matchesTag = !activeTag || tags.includes(activeTag);
+
+        const visible = matchesSearch && matchesTag;
+        li.hidden = !visible;
+        if (visible) visibleCount++;
+      });
+
+      if (noResults) noResults.hidden = visibleCount > 0;
+    };
+
+    const setActiveTag = (tag) => {
+      activeTag = tag;
+      // Update button styles
+      document.querySelectorAll('.tag-btn, .tag-chip').forEach((btn) => {
+        btn.classList.toggle('active', btn.dataset.tag === activeTag);
+      });
+      applyFilters();
+    };
+
+    searchInput.addEventListener('input', applyFilters);
+
+    // Pre-select tag from URL (?tag=foo)
+    const urlTag = new URLSearchParams(window.location.search).get('tag');
+    if (urlTag) setActiveTag(urlTag);
+
+    // Tag bar filter buttons
+    if (tagBar) {
+      tagBar.addEventListener('click', (e) => {
+        const btn = e.target.closest('.tag-btn');
+        if (!btn) return;
+        const tag = btn.dataset.tag;
+        setActiveTag(activeTag === tag ? null : tag);
+      });
+    }
+
+    // Tag chips on individual posts
+    postList.addEventListener('click', (e) => {
+      const btn = e.target.closest('.tag-chip');
+      if (!btn) return;
+      const tag = btn.dataset.tag;
+      setActiveTag(activeTag === tag ? null : tag);
+    });
+  })();
+</script>
 
 <style>
   .output {
@@ -42,22 +161,117 @@ const sortedPosts = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDa
     color: var(--term-green);
   }
 
+  /* ── search & tag bar ── */
+  .controls {
+    display: grid;
+    gap: 8px;
+  }
+
+  .search-input {
+    width: 100%;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid rgba(97, 175, 239, 0.25);
+    color: var(--term-fg);
+    font: inherit;
+    padding: 4px 0;
+    caret-color: var(--term-green);
+  }
+
+  .search-input::placeholder {
+    color: var(--term-dim);
+    opacity: 0.65;
+  }
+
+  .search-input:focus {
+    outline: none;
+    border-bottom-color: rgba(97, 175, 239, 0.6);
+  }
+
+  /* Remove browser search clear button */
+  .search-input::-webkit-search-cancel-button {
+    display: none;
+  }
+
+  .tag-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .tag-btn,
+  .tag-chip {
+    background: transparent;
+    border: 1px solid rgba(97, 175, 239, 0.3);
+    border-radius: 4px;
+    color: var(--term-dim);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.78rem;
+    line-height: 1;
+    padding: 3px 7px;
+    transition: border-color 120ms, color 120ms, background 120ms;
+  }
+
+  .tag-btn:hover,
+  .tag-chip:hover {
+    border-color: var(--term-blue);
+    color: var(--term-blue);
+  }
+
+  .tag-btn.active,
+  .tag-chip.active {
+    background: rgba(97, 175, 239, 0.15);
+    border-color: var(--term-blue);
+    color: var(--term-blue);
+  }
+
+  /* ── post list ── */
   .post-list {
     margin: 0;
     padding: 0;
     list-style: none;
     display: grid;
-    gap: 8px;
+    gap: 10px;
   }
 
   .post-list li {
+    display: grid;
+    gap: 4px;
+  }
+
+  .post-row {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
+    align-items: baseline;
   }
 
   .post-list time {
     color: var(--term-dim);
     min-width: 112px;
+  }
+
+  .post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .no-results {
+    color: var(--term-dim);
+    margin: 0;
   }
 </style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -49,9 +49,9 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
             <a href={`/blog/${post.slug}`}>{post.data.title}</a>
           </div>
           {post.data.tags && post.data.tags.length > 0 && (
-            <div class="post-tags" aria-label="Tags">
+            <div class="post-tags" role="group" aria-label="Tags">
               {post.data.tags.map((tag) => (
-                <button class="tag-chip" data-tag={tag} type="button">#{tag}</button>
+                <button class="tag-chip" data-tag={tag} type="button" aria-pressed="false">#{tag}</button>
               ))}
             </div>
           )}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -7,20 +7,6 @@ const sortedPosts = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDa
 
 // Collect all unique tags across posts for the filter bar
 const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort();
-
-// Serialise post data for client-side search/filter
-const postData = sortedPosts.map((post) => ({
-  slug: post.slug,
-  title: post.data.title,
-  description: post.data.description,
-  tags: post.data.tags ?? [],
-  date: post.data.pubDate.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: '2-digit',
-  }),
-  dateIso: post.data.pubDate.toISOString(),
-}));
 ---
 
 <BaseLayout title="Blog | Pasha Fateev" path="~/blog" status={`POSTS ${sortedPosts.length}`}>
@@ -41,15 +27,15 @@ const postData = sortedPosts.map((post) => ({
         />
       </div>
       {allTags.length > 0 && (
-        <div class="tag-bar" id="tag-bar" aria-label="Filter by tag">
+        <div class="tag-bar" id="tag-bar" role="group" aria-label="Filter by tag">
           {allTags.map((tag) => (
-            <button class="tag-btn" data-tag={tag} type="button">#{tag}</button>
+            <button class="tag-btn" data-tag={tag} type="button" aria-pressed="false">#{tag}</button>
           ))}
         </div>
       )}
     </div>
 
-    <ul class="post-list" id="post-list" data-posts={JSON.stringify(postData)}>
+    <ul class="post-list" id="post-list">
       {sortedPosts.map((post) => (
         <li data-title={post.data.title.toLowerCase()} data-desc={post.data.description.toLowerCase()} data-tags={(post.data.tags ?? []).join(',')}>
           <div class="post-row">
@@ -114,9 +100,11 @@ const postData = sortedPosts.map((post) => ({
 
     const setActiveTag = (tag) => {
       activeTag = tag;
-      // Update button styles
+      // Update button styles and ARIA pressed state
       document.querySelectorAll('.tag-btn, .tag-chip').forEach((btn) => {
-        btn.classList.toggle('active', btn.dataset.tag === activeTag);
+        const isActive = btn.dataset.tag === activeTag;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-pressed', String(isActive));
       });
       applyFilters();
     };


### PR DESCRIPTION
Closes #38, closes #39

## What

Adds tags and search to the blog index, completing both Phase 4 blog-discoverability issues.

### #38 – Blog Tags/Categories
- **Tag chips under each post** on the listing page (e.g. `#ai`, `#projects`)
- **Tag filter bar** at the top of `/blog` showing all unique tags across posts; clicking any tag toggles a filter that narrows the visible posts
- **Clickable tag chips on individual posts** (`BlogPost.astro`) that deep-link to `/blog?tag=<name>`, pre-selecting that filter on arrival
- **URL param pre-selection**: on page load, `?tag=` is read and the matching filter is activated automatically
- Upgraded the BlogPost tag display from plain comma-separated text to styled chip links

### #39 – Blog Search
- **Search input** above the post list with a `grep -r ...` placeholder (fits the terminal aesthetic)
- Filters by post title **and** description in real time as the user types
- Search and tag filter **compose**: both can be active simultaneously
- Hidden "No posts match your search." message shown when all posts are filtered out
- No new JS dependencies — simple client-side string matching is sufficient for the current post count

### Content
- Added `tags` frontmatter to `building-mycel.md` (`ai`, `projects`, `mycel`) and `one-in-the-morning.md` (`ai`, `thoughts`); `welcome.md` already had tags

## Verification

```
pnpm build  # zero errors, 5 pages built
```
