### PR TITLE
Improve terminal emulation realism

### DIFF
--- a/src/components/Prompt.astro
+++ b/src/components/Prompt.astro
@@ -95,11 +95,35 @@
       return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
     };
 
+    const LINE_DELAY = 18;
+    const printQueue = [];
+    let printing = false;
+
     const trimOutput = () => {
       while (output.childElementCount > MAX_OUTPUT_LINES) {
         output.firstElementChild?.remove();
       }
       output.scrollTop = output.scrollHeight;
+    };
+
+    const flushQueue = () => {
+      if (printing || printQueue.length === 0) return;
+      printing = true;
+      const drain = () => {
+        if (printQueue.length === 0) {
+          printing = false;
+          return;
+        }
+        const el = printQueue.shift();
+        output.appendChild(el);
+        trimOutput();
+        if (printQueue.length > 0) {
+          setTimeout(drain, LINE_DELAY);
+        } else {
+          printing = false;
+        }
+      };
+      drain();
     };
 
     const appendCommand = (text) => {
@@ -117,6 +141,14 @@
     };
 
     const appendResponse = (text) => {
+      const line = document.createElement('p');
+      line.className = 'prompt-line prompt-line-response';
+      line.textContent = text;
+      printQueue.push(line);
+      flushQueue();
+    };
+
+    const appendResponseImmediate = (text) => {
       const line = document.createElement('p');
       line.className = 'prompt-line prompt-line-response';
       line.textContent = text;
@@ -138,8 +170,8 @@
       }
 
       line.appendChild(anchor);
-      output.appendChild(line);
-      trimOutput();
+      printQueue.push(line);
+      flushQueue();
     };
 
     const printHelp = () => {
@@ -164,6 +196,8 @@
 
       // Preserve terminal behavior: clear should wipe the screen entirely, including the typed line.
       if (cmd === 'clear') {
+        printQueue.length = 0;
+        printing = false;
         output.innerHTML = '';
         output.scrollTop = 0;
         const terminalContent = section.closest('.terminal-content') || section.parentElement;
@@ -371,7 +405,7 @@
     });
 
     // Print MOTD then auto-focus so the session starts feeling like a real shell (#21, #22, #49)
-    appendResponse("type 'help' for a list of commands.");
+    appendResponseImmediate("type 'help' for a list of commands.");
     requestAnimationFrame(() => input.focus());
   })();
 </script>
@@ -379,21 +413,25 @@
 <style>
   .prompt-shell {
     display: grid;
-    gap: 10px;
+    gap: 2px;
     margin-top: 4px;
   }
 
   .prompt-output {
-    display: grid;
-    gap: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
     max-height: min(48vh, 320px);
     overflow-y: auto;
     padding-right: 4px;
+    line-height: 1.3;
   }
 
   .prompt-line {
     margin: 0;
+    white-space: pre-wrap;
     word-break: break-word;
+    font-variant-ligatures: none;
   }
 
   .prompt-line-command {
@@ -401,7 +439,8 @@
   }
 
   .prompt-line-response {
-    color: var(--term-dim);
+    color: var(--term-fg);
+    text-shadow: 0 0 2px rgba(197, 200, 198, 0.15);
   }
 
   .prompt-entry {
@@ -410,7 +449,8 @@
     grid-template-columns: auto minmax(0, 1fr);
     gap: 8px;
     align-items: center;
-    min-height: 44px;
+    min-height: 1.3em;
+    padding: 2px 0;
   }
   
   .prompt-entry .cursor {
@@ -435,7 +475,8 @@
     color: var(--term-fg);
     background: transparent;
     font: inherit;
-    min-height: 44px;
+    line-height: 1.3;
+    min-height: 0;
     padding: 0;
     caret-color: transparent;
   }
@@ -458,9 +499,7 @@
   .prompt-link {
     color: var(--term-blue);
     text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    min-height: 44px;
+    text-decoration-skip-ink: auto;
   }
 
   .prompt-link:hover,

--- a/src/components/Prompt.astro
+++ b/src/components/Prompt.astro
@@ -95,9 +95,11 @@
       return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
     };
 
-    const LINE_DELAY = 18;
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const LINE_DELAY = prefersReducedMotion ? 0 : 18;
     const printQueue = [];
     let printing = false;
+    let drainTimer = 0;
 
     const trimOutput = () => {
       while (output.childElementCount > MAX_OUTPUT_LINES) {
@@ -112,15 +114,17 @@
       const drain = () => {
         if (printQueue.length === 0) {
           printing = false;
+          drainTimer = 0;
           return;
         }
         const el = printQueue.shift();
         output.appendChild(el);
         trimOutput();
         if (printQueue.length > 0) {
-          setTimeout(drain, LINE_DELAY);
+          drainTimer = setTimeout(drain, LINE_DELAY);
         } else {
           printing = false;
+          drainTimer = 0;
         }
       };
       drain();
@@ -196,6 +200,8 @@
 
       // Preserve terminal behavior: clear should wipe the screen entirely, including the typed line.
       if (cmd === 'clear') {
+        clearTimeout(drainTimer);
+        drainTimer = 0;
         printQueue.length = 0;
         printing = false;
         output.innerHTML = '';
@@ -506,6 +512,18 @@
   .prompt-link:focus-visible {
     color: var(--term-green);
     text-decoration: underline;
+  }
+
+  @media (pointer: coarse) {
+    .prompt-entry {
+      min-height: 44px;
+    }
+
+    .prompt-link {
+      display: inline-flex;
+      align-items: center;
+      min-height: 44px;
+    }
   }
 
   .sr-only {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,7 +40,7 @@ const ogImageURL = new URL(image, Astro.site);
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=VT323&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap" rel="stylesheet">
     <script is:inline>
       try {
         const nav = performance.getEntriesByType('navigation')[0];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,7 +40,7 @@ const ogImageURL = new URL(image, Astro.site);
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=VT323&display=swap" rel="stylesheet">
     <script is:inline>
       try {
         const nav = performance.getEntriesByType('navigation')[0];

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,12 +25,12 @@ body {
 
 html {
   background: var(--term-bg);
-  font-size: clamp(16px, 1vw + 12px, 20px);
+  font-size: clamp(14px, 0.95vw + 11px, 16px);
 }
 
 body {
   min-height: 100vh;
-  font-family: "VT323", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 1rem;
   color: var(--term-fg);
   background:

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,12 +25,12 @@ body {
 
 html {
   background: var(--term-bg);
-  font-size: clamp(14px, 0.95vw + 11px, 16px);
+  font-size: clamp(16px, 1vw + 12px, 20px);
 }
 
 body {
   min-height: 100vh;
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: "VT323", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 1rem;
   color: var(--term-fg);
   background:


### PR DESCRIPTION
## Summary
- Output text now renders in proper foreground color instead of dim gray, matching real terminal behavior
- Added line-by-line progressive rendering (18ms delay per line) via a print queue, simulating how real terminals stream output
- Tightened line spacing, whitespace handling (`pre-wrap`), and prompt sizing for dense, authentic terminal feel
- Removed oversized tap targets and disabled ligatures for true monospace appearance

## Test plan
- [ ] Run `help` and verify output prints line-by-line with slight delay
- [ ] Run `neofetch` and confirm aligned columns render correctly with `pre-wrap`
- [ ] Run `cowsay` and verify ASCII art spacing is preserved
- [ ] Run `clear` mid-output (e.g. during `matrix`) and confirm output stops and clears
- [ ] Verify output text color is bright (not dim gray) across all commands
- [ ] Check mobile layout still looks correct with tighter spacing

https://claude.ai/code/session_01LYpjdsx4ypVzeecNFkbghi