### PR TITLE
Fix misleading terminal UI: blog cursor and ? shortcut

### DIFF
--- a/src/components/Prompt.astro
+++ b/src/components/Prompt.astro
@@ -88,13 +88,6 @@
       cursor.style.height = `${cursorHeight}px`;
     };
 
-    const isEditableTarget = (target) => {
-      if (!(target instanceof HTMLElement)) return false;
-      if (target.isContentEditable) return true;
-      const tag = target.tagName;
-      return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
-    };
-
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const LINE_DELAY = prefersReducedMotion ? 0 : 18;
     const printQueue = [];
@@ -395,8 +388,6 @@
       if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey) {
         return;
       }
-
-      const target = event.target;
 
       if (event.key === 'Escape' && document.activeElement === input) {
         input.blur();

--- a/src/components/Prompt.astro
+++ b/src/components/Prompt.astro
@@ -188,7 +188,7 @@
       appendResponse('cowsay   - make a cow say something');
       appendResponse('help     - show this help');
       appendResponse('──────────────────────────────────────');
-      appendResponse('Shortcuts: Tab complete  ? help');
+      appendResponse('Shortcuts: Tab complete');
     };
 
     const runCommand = (rawValue) => {
@@ -397,13 +397,6 @@
       }
 
       const target = event.target;
-
-      if (event.key === '?' && !isEditableTarget(target)) {
-        event.preventDefault();
-        input.focus();
-        printHelp();
-        return;
-      }
 
       if (event.key === 'Escape' && document.activeElement === input) {
         input.blur();

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -24,7 +24,7 @@ const sortedPosts = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDa
       ))}
     </ul>
     <p><span class="prompt">pasha@portfolio:~/blog$</span> cd ..</p>
-    <p><a href="/">back to home</a><span class="cursor"></span></p>
+    <p><a href="/">back to home</a></p>
   </div>
 </BaseLayout>
 


### PR DESCRIPTION
## Summary\n- Remove non-interactive blinking cursor from the blog index page — it implied the terminal was interactive when it isn't (#53)\n- Remove the `?` keyboard shortcut and its mention in the help text — pressing `?` triggered help but wasn't discoverable and felt broken as a \"command\" (#54)\n\n## Test plan\n- [ ] Visit `/blog` and confirm no blinking cursor appears after the \"back to home\" link\n- [ ] On the homepage, press `?` outside the input — confirm it does nothing (no help printed)\n- [ ] Run the `help` command — confirm shortcuts line reads \"Shortcuts: Tab complete\" without `? help`\n- [ ] Verify `help` command and Tab completion still work normally\n\nCloses #53, closes #54\n\nhttps://claude.ai/code/session_01QmeAx5ipq5mwtAtciLWkuh