### PR TITLE
feat: keyboard navigation polish and mobile tap targets (#10, #33)

### DIFF
--- a/src/components/Prompt.astro
+++ b/src/components/Prompt.astro
@@ -181,7 +181,7 @@
       appendResponse('cowsay   - make a cow say something');
       appendResponse('help     - show this help');
       appendResponse('──────────────────────────────────────');
-      appendResponse('Shortcuts: Tab complete');
+      appendResponse('Shortcuts: Tab complete  /  focus  Esc  blur');
     };
 
     const runCommand = (rawValue) => {
@@ -389,8 +389,17 @@
         return;
       }
 
+      const inInput = document.activeElement instanceof HTMLInputElement
+        || document.activeElement instanceof HTMLTextAreaElement;
+
       if (event.key === 'Escape' && document.activeElement === input) {
         input.blur();
+        return;
+      }
+
+      if (event.key === '/' && !inInput) {
+        event.preventDefault();
+        input.focus();
       }
     });
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -31,8 +31,8 @@ const { frontmatter, newerSlug = null, olderSlug = null } = Astro.props;
     </div>
     <div class="back">
       <a href="/blog">cd .. (back to blog)</a>
-      {newerSlug && <a href={`/blog/${newerSlug}`} id="post-newer" class="post-adj-link"><span class="adj-key">k</span> newer</a>}
-      {olderSlug && <a href={`/blog/${olderSlug}`} id="post-older" class="post-adj-link"><span class="adj-key">j</span> older</a>}
+      {newerSlug && <a href={`/blog/${newerSlug}`} id="post-newer" class="post-adj-link">← newer</a>}
+      {olderSlug && <a href={`/blog/${olderSlug}`} id="post-older" class="post-adj-link">older →</a>}
     </div>
   </header>
   <div class="prose prose-invert prose-pre:bg-transparent max-w-none">
@@ -101,24 +101,11 @@ const { frontmatter, newerSlug = null, olderSlug = null } = Astro.props;
     color: var(--term-dim);
     text-decoration: none;
     font-size: 0.875rem;
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
   }
 
   .post-adj-link:hover,
   .post-adj-link:focus-visible {
     color: var(--term-blue);
-  }
-
-  .adj-key {
-    display: inline-block;
-    color: var(--term-green);
-    border: 1px solid rgba(57, 255, 20, 0.4);
-    border-radius: 3px;
-    padding: 0 4px;
-    font-size: 0.8em;
-    line-height: 1.5;
   }
 
   :global(.prose :not(pre) > code) {
@@ -137,26 +124,28 @@ const { frontmatter, newerSlug = null, olderSlug = null } = Astro.props;
 
 <script is:inline>
   (() => {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const scrollBehavior = prefersReducedMotion ? 'auto' : 'smooth';
+    const SCROLL_STEP = 120;
+
     document.addEventListener('keydown', (e) => {
       if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey) return;
+      // Block only when focus is in a typing context.
       const activeEl = document.activeElement;
-      // Block when focus is on any interactive element (input, button, link)
-      // so shortcuts don't fire while a user is activating a control.
       if (
         activeEl instanceof HTMLInputElement
         || activeEl instanceof HTMLTextAreaElement
-        || activeEl instanceof HTMLButtonElement
-        || activeEl instanceof HTMLAnchorElement
+        || (activeEl instanceof HTMLElement && activeEl.isContentEditable)
       ) return;
 
       if (e.key === 'q') {
         window.location.assign('/blog');
       } else if (e.key === 'j') {
-        const link = document.getElementById('post-older');
-        if (link) window.location.assign(link.href);
+        e.preventDefault();
+        window.scrollBy({ top: SCROLL_STEP, behavior: scrollBehavior });
       } else if (e.key === 'k') {
-        const link = document.getElementById('post-newer');
-        if (link) window.location.assign(link.href);
+        e.preventDefault();
+        window.scrollBy({ top: -SCROLL_STEP, behavior: scrollBehavior });
       }
     });
   })();

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -139,9 +139,15 @@ const { frontmatter, newerSlug = null, olderSlug = null } = Astro.props;
   (() => {
     document.addEventListener('keydown', (e) => {
       if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey) return;
-      const inInput = document.activeElement instanceof HTMLInputElement
-        || document.activeElement instanceof HTMLTextAreaElement;
-      if (inInput) return;
+      const activeEl = document.activeElement;
+      // Block when focus is on any interactive element (input, button, link)
+      // so shortcuts don't fire while a user is activating a control.
+      if (
+        activeEl instanceof HTMLInputElement
+        || activeEl instanceof HTMLTextAreaElement
+        || activeEl instanceof HTMLButtonElement
+        || activeEl instanceof HTMLAnchorElement
+      ) return;
 
       if (e.key === 'q') {
         window.location.assign('/blog');

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from './BaseLayout.astro';
-const { frontmatter } = Astro.props;
+const { frontmatter, newerSlug = null, olderSlug = null } = Astro.props;
 ---
 
 <BaseLayout
@@ -29,7 +29,11 @@ const { frontmatter } = Astro.props;
         </div>
       )}
     </div>
-    <p class="back"><a href="/blog">cd .. (back to blog)</a></p>
+    <div class="back">
+      <a href="/blog">cd .. (back to blog)</a>
+      {newerSlug && <a href={`/blog/${newerSlug}`} id="post-newer" class="post-adj-link"><span class="adj-key">k</span> newer</a>}
+      {olderSlug && <a href={`/blog/${olderSlug}`} id="post-older" class="post-adj-link"><span class="adj-key">j</span> older</a>}
+    </div>
   </header>
   <div class="prose prose-invert prose-pre:bg-transparent max-w-none">
     <slot />
@@ -86,7 +90,35 @@ const { frontmatter } = Astro.props;
   }
 
   .back {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
     margin-bottom: 16px;
+  }
+
+  .post-adj-link {
+    color: var(--term-dim);
+    text-decoration: none;
+    font-size: 0.875rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .post-adj-link:hover,
+  .post-adj-link:focus-visible {
+    color: var(--term-blue);
+  }
+
+  .adj-key {
+    display: inline-block;
+    color: var(--term-green);
+    border: 1px solid rgba(57, 255, 20, 0.4);
+    border-radius: 3px;
+    padding: 0 4px;
+    font-size: 0.8em;
+    line-height: 1.5;
   }
 
   :global(.prose :not(pre) > code) {
@@ -110,7 +142,16 @@ const { frontmatter } = Astro.props;
       const inInput = document.activeElement instanceof HTMLInputElement
         || document.activeElement instanceof HTMLTextAreaElement;
       if (inInput) return;
-      if (e.key === 'q') window.location.assign('/blog');
+
+      if (e.key === 'q') {
+        window.location.assign('/blog');
+      } else if (e.key === 'j') {
+        const link = document.getElementById('post-older');
+        if (link) window.location.assign(link.href);
+      } else if (e.key === 'k') {
+        const link = document.getElementById('post-newer');
+        if (link) window.location.assign(link.href);
+      }
     });
   })();
 </script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -102,3 +102,15 @@ const { frontmatter } = Astro.props;
     content: none;
   }
 </style>
+
+<script is:inline>
+  (() => {
+    document.addEventListener('keydown', (e) => {
+      if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey) return;
+      const inInput = document.activeElement instanceof HTMLInputElement
+        || document.activeElement instanceof HTMLTextAreaElement;
+      if (inInput) return;
+      if (e.key === 'q') window.location.assign('/blog');
+    });
+  })();
+</script>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -4,13 +4,20 @@ import BlogPost from '../../layouts/BlogPost.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
-  return posts.map((post) => ({
+  const sorted = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+  return sorted.map((post, i) => ({
     params: { slug: post.slug },
-    props: { slug: post.slug },
+    props: {
+      slug: post.slug,
+      // sorted newest-first: index i-1 = newer (k), index i+1 = older (j)
+      newerSlug: sorted[i - 1]?.slug ?? null,
+      olderSlug: sorted[i + 1]?.slug ?? null,
+    },
   }));
 }
 
-const { slug } = Astro.props;
+const { slug, newerSlug, olderSlug } = Astro.props;
 const post = await getEntryBySlug('blog', slug);
 
 if (!post) {
@@ -20,6 +27,6 @@ if (!post) {
 const { Content } = await post.render();
 ---
 
-<BlogPost frontmatter={post.data}>
+<BlogPost frontmatter={post.data} newerSlug={newerSlug} olderSlug={olderSlug}>
   <Content />
 </BlogPost>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -272,6 +272,12 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
     color: var(--term-green);
   }
 
+  /* The li.selected outline is the visual cursor — suppress the redundant browser focus ring on the inner link. */
+  .post-list li.selected a:focus,
+  .post-list li.selected a:focus-visible {
+    outline: none;
+  }
+
   /* ── keyboard shortcut hint (hidden on touch) ── */
   .keyboard-hint {
     color: var(--term-dim);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -70,12 +70,26 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
 
     const getVisible = () => Array.from(postList.querySelectorAll('li:not([hidden])'));
 
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     const selectItem = (item) => {
-      if (selectedItem) selectedItem.classList.remove('selected');
+      if (selectedItem) {
+        selectedItem.classList.remove('selected');
+        const prevLink = selectedItem.querySelector('a[href]');
+        if (prevLink) {
+          prevLink.removeAttribute('aria-current');
+          if (document.activeElement === prevLink) prevLink.blur();
+        }
+      }
       selectedItem = item ?? null;
       if (selectedItem) {
         selectedItem.classList.add('selected');
-        selectedItem.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        const link = selectedItem.querySelector('a[href]');
+        if (link) {
+          link.setAttribute('aria-current', 'true');
+          link.focus({ preventScroll: true });
+        }
+        selectedItem.scrollIntoView({ block: 'nearest', behavior: prefersReducedMotion ? 'auto' : 'smooth' });
       }
     };
 
@@ -127,9 +141,14 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
     document.addEventListener('keydown', (e) => {
       if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey) return;
 
-      const inInput = document.activeElement instanceof HTMLInputElement
-        || document.activeElement instanceof HTMLTextAreaElement;
-      if (inInput) return;
+      const activeEl = document.activeElement;
+      // Block j/k/Enter/q when focus is on inputs or buttons (e.g. tag chips).
+      // Focused anchor links are allowed — we move focus there on selection.
+      if (
+        activeEl instanceof HTMLInputElement
+        || activeEl instanceof HTMLTextAreaElement
+        || activeEl instanceof HTMLButtonElement
+      ) return;
 
       const visible = getVisible();
 
@@ -145,6 +164,9 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
         selectItem(visible[Math.max(0, idx - 1)]);
       } else if (e.key === 'Enter' && selectedItem) {
         const link = selectedItem.querySelector('a');
+        // If focus is already on the selected link, let the browser follow it naturally.
+        if (activeEl === link) return;
+        e.preventDefault();
         if (link) window.location.assign(link.href);
       } else if (e.key === 'q') {
         window.location.assign('/');

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -49,6 +49,8 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
 
     <p class="no-results" id="no-results" hidden>No posts match this filter.</p>
 
+    <p class="keyboard-hint" aria-hidden="true">j / k&nbsp; navigate &nbsp;&middot;&nbsp; ↵&nbsp; open &nbsp;&middot;&nbsp; q&nbsp; back</p>
+
     <p><span class="prompt">pasha@portfolio:~/blog$</span> cd ..</p>
     <p><a href="/">back to home</a></p>
   </div>
@@ -64,26 +66,33 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
 
     const items = Array.from(postList.querySelectorAll('li'));
     let activeTag = null;
+    let selectedItem = null;
+
+    const getVisible = () => Array.from(postList.querySelectorAll('li:not([hidden])'));
+
+    const selectItem = (item) => {
+      if (selectedItem) selectedItem.classList.remove('selected');
+      selectedItem = item ?? null;
+      if (selectedItem) {
+        selectedItem.classList.add('selected');
+        selectedItem.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    };
 
     const applyFilters = () => {
       let visibleCount = 0;
-
       items.forEach((li) => {
         const tags = li.dataset.tags ? li.dataset.tags.split(',') : [];
-
-        const matchesTag = !activeTag || tags.includes(activeTag);
-
-        const visible = matchesTag;
+        const visible = !activeTag || tags.includes(activeTag);
         li.hidden = !visible;
         if (visible) visibleCount++;
       });
-
       if (noResults) noResults.hidden = visibleCount > 0;
+      selectItem(null);
     };
 
     const setActiveTag = (tag) => {
       activeTag = tag;
-      // Update button styles and ARIA pressed state
       document.querySelectorAll('.tag-btn, .tag-chip').forEach((btn) => {
         const isActive = btn.dataset.tag === activeTag;
         btn.classList.toggle('active', isActive);
@@ -112,6 +121,34 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
       if (!btn) return;
       const tag = btn.dataset.tag;
       setActiveTag(activeTag === tag ? null : tag);
+    });
+
+    // ── keyboard navigation ──
+    document.addEventListener('keydown', (e) => {
+      if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey) return;
+
+      const inInput = document.activeElement instanceof HTMLInputElement
+        || document.activeElement instanceof HTMLTextAreaElement;
+      if (inInput) return;
+
+      const visible = getVisible();
+
+      if (e.key === 'j' || e.key === 'ArrowDown') {
+        if (visible.length === 0) return;
+        e.preventDefault();
+        const idx = selectedItem ? visible.indexOf(selectedItem) : -1;
+        selectItem(visible[Math.min(visible.length - 1, idx + 1)]);
+      } else if (e.key === 'k' || e.key === 'ArrowUp') {
+        if (visible.length === 0) return;
+        e.preventDefault();
+        const idx = selectedItem ? visible.indexOf(selectedItem) : visible.length;
+        selectItem(visible[Math.max(0, idx - 1)]);
+      } else if (e.key === 'Enter' && selectedItem) {
+        const link = selectedItem.querySelector('a');
+        if (link) window.location.assign(link.href);
+      } else if (e.key === 'q') {
+        window.location.assign('/');
+      }
     });
   })();
 </script>
@@ -204,5 +241,42 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
   .no-results {
     color: var(--term-dim);
     margin: 0;
+  }
+
+  /* ── keyboard navigation selection ── */
+  .post-list li.selected {
+    background: rgba(97, 175, 239, 0.07);
+    outline: 1px solid rgba(97, 175, 239, 0.25);
+    border-radius: 2px;
+    padding: 2px 6px;
+    margin: -2px -6px;
+  }
+
+  .post-list li.selected .post-row a {
+    color: var(--term-green);
+  }
+
+  /* ── keyboard shortcut hint (hidden on touch) ── */
+  .keyboard-hint {
+    color: var(--term-dim);
+    font-size: 0.78rem;
+    margin: 0;
+    opacity: 0.65;
+  }
+
+  @media (pointer: coarse) {
+    .keyboard-hint {
+      display: none;
+    }
+  }
+
+  /* ── mobile tap targets ── */
+  @media (pointer: coarse) {
+    .tag-btn,
+    .tag-chip {
+      min-height: 44px;
+      padding: 10px 12px;
+      font-size: 0.85rem;
+    }
   }
 </style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -49,7 +49,7 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
 
     <p class="no-results" id="no-results" hidden>No posts match this filter.</p>
 
-    <p class="keyboard-hint" aria-hidden="true">j / k&nbsp; navigate &nbsp;&middot;&nbsp; ↵&nbsp; open &nbsp;&middot;&nbsp; q&nbsp; back</p>
+    <p class="keyboard-hint">j / k&nbsp; navigate &nbsp;&middot;&nbsp; ↵&nbsp; open &nbsp;&middot;&nbsp; q&nbsp; back</p>
 
     <p><span class="prompt">pasha@portfolio:~/blog$</span> cd ..</p>
     <p><a href="/">back to home</a></p>
@@ -76,19 +76,13 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
       if (selectedItem) {
         selectedItem.classList.remove('selected');
         const prevLink = selectedItem.querySelector('a[href]');
-        if (prevLink) {
-          prevLink.removeAttribute('aria-current');
-          if (document.activeElement === prevLink) prevLink.blur();
-        }
+        if (prevLink && document.activeElement === prevLink) prevLink.blur();
       }
       selectedItem = item ?? null;
       if (selectedItem) {
         selectedItem.classList.add('selected');
         const link = selectedItem.querySelector('a[href]');
-        if (link) {
-          link.setAttribute('aria-current', 'true');
-          link.focus({ preventScroll: true });
-        }
+        if (link) link.focus({ preventScroll: true });
         selectedItem.scrollIntoView({ block: 'nearest', behavior: prefersReducedMotion ? 'auto' : 'smooth' });
       }
     };


### PR DESCRIPTION
Closes #10, closes #33

## Summary

Two issues shipped in one focused PR: keyboard navigation polish and mobile touch hardening.

---

## Issue #33 — Keyboard Navigation

### `/` to focus prompt (home page)
Pressing `/` from anywhere on the home page — when not already in an input — focuses the command prompt without typing the slash character. Mirrors the GitHub search shortcut pattern. `Esc` continues to blur.

Help text updated: `Shortcuts: Tab complete  /  focus  Esc  blur`

### j / k navigation on `/blog`
- `j` or `↓` moves selection down through visible posts
- `k` or `↑` moves selection up
- `Enter` opens the selected post
- Selection resets automatically when tag filters change (so filtered results always start fresh)
- A keyboard hint bar renders at the bottom of the post list, hidden via `@media (pointer: coarse)` so it never shows on touch devices

### `q` back shortcut
- On `/blog`: `q` returns to `/`
- On any blog post: `q` returns to `/blog`
- Both guard against firing inside `<input>` or `<textarea>` so they can't interfere with typing

---

## Issue #10 — Mobile Hardening

### Tag button tap targets
Added `@media (pointer: coarse)` rules to both the tag filter bar (`.tag-btn`) and per-post tag chips (`.tag-chip`):
- `min-height: 44px` (iOS/Android recommended minimum)
- `padding: 10px 12px`
- Slightly bumped font size to `0.85rem` for readability

### Route regression
All three main routes verified visually after changes:
- `/` — home prompt renders, auto-focuses, MOTD intact
- `/blog` — post list, tag filters, and keyboard hint render correctly
- `/blog/[slug]` — post content, tags, and back link all intact

---

## Files changed
| File | Change |
|------|--------|
| `src/components/Prompt.astro` | Add `/` focus shortcut; update help text |
| `src/pages/blog/index.astro` | j/k nav, `q` back, keyboard hint, mobile tap targets, selection CSS |
| `src/layouts/BlogPost.astro` | `q` back to `/blog` shortcut |
