### PR TITLE
fix: mobile touch improvements (#45)

### DIFF
--- a/src/components/Prompt.astro
+++ b/src/components/Prompt.astro
@@ -17,6 +17,8 @@
     <span class="cursor" aria-hidden="true"></span>
   </div>
 
+  <p class="prompt-tap-hint" aria-hidden="true">tap to type</p>
+
   <noscript>
     <p class="prompt-hint">JavaScript is off. Visit <a href="/blog">/blog</a> or open <a href="/files/resume-cv.pdf">resume.pdf</a>.</p>
   </noscript>
@@ -330,9 +332,11 @@
     input.addEventListener('click', updateCursorPosition);
     input.addEventListener('keyup', updateCursorPosition);
     
-    // Show/hide cursor based on focus
+    // Show/hide cursor based on focus; hide tap hint on first interaction
+    const tapHint = section?.querySelector('.prompt-tap-hint');
     input.addEventListener('focus', () => {
       if (cursor) cursor.style.opacity = '1';
+      if (tapHint) tapHint.hidden = true;
       updateCursorPosition();
     });
     
@@ -403,9 +407,12 @@
       }
     });
 
-    // Print MOTD then auto-focus so the session starts feeling like a real shell (#21, #22, #49)
+    // Print MOTD. Only auto-focus on pointer devices — on touch, focusing the input
+    // immediately pops the software keyboard before the visitor has read anything.
     appendResponseImmediate("type 'help' for a list of commands.");
-    requestAnimationFrame(() => input.focus());
+    if (!window.matchMedia('(pointer: coarse)').matches) {
+      requestAnimationFrame(() => input.focus());
+    }
   })();
 </script>
 
@@ -493,6 +500,20 @@
     margin: 0;
     color: var(--term-dim);
     font-size: 0.9rem;
+  }
+
+  .prompt-tap-hint {
+    display: none;
+    margin: 6px 0 0;
+    color: var(--term-dim);
+    font-size: 0.8rem;
+    opacity: 0.55;
+  }
+
+  @media (pointer: coarse) {
+    .prompt-tap-hint {
+      display: block;
+    }
   }
 
   .prompt-link {

--- a/src/components/Terminal.astro
+++ b/src/components/Terminal.astro
@@ -110,6 +110,14 @@ const { path = '~', status = 'READY' } = Astro.props;
     display: flex;
     align-items: center;
     gap: 10px;
+    min-width: 0;
+  }
+
+  .terminal-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
   }
 
   .terminal-avatar {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -108,6 +108,22 @@ const { frontmatter, newerSlug = null, olderSlug = null } = Astro.props;
     color: var(--term-blue);
   }
 
+  @media (pointer: coarse) {
+    .tag-chip {
+      min-height: 44px;
+      padding: 10px 12px;
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .back a,
+    .post-adj-link {
+      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+    }
+  }
+
   :global(.prose :not(pre) > code) {
     color: var(--term-green);
     background: rgba(97, 175, 239, 0.12);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -300,5 +300,11 @@ const allTags = [...new Set(sortedPosts.flatMap((p) => p.data.tags ?? []))].sort
       padding: 10px 12px;
       font-size: 0.85rem;
     }
+
+    .post-row a {
+      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+    }
   }
 </style>


### PR DESCRIPTION
Closes #45

## What changed

Four files, six targeted fixes — all scoped to `@media (pointer: coarse)` or guard conditions so desktop is untouched.

### `Prompt.astro` — two fixes

**Auto-focus guard**
`requestAnimationFrame(() => input.focus())` was firing unconditionally. On touch devices this pops the software keyboard the moment the page loads, before the visitor has read a single word. Now guarded:
```js
if (!window.matchMedia('(pointer: coarse)').matches) {
  requestAnimationFrame(() => input.focus());
}
```

**Tap-to-type hint**
With auto-focus gone, the prompt looks like inert text on mobile — the cursor is opacity 0 when unfocused. Added a `<p class="prompt-tap-hint">tap to type</p>` element that is display:none on desktop (pointer:fine), shown on coarse-pointer devices, and hidden via JS on first focus so it doesn't linger after the user interacts.

### `BlogPost.astro` — tag chips and nav links

Tag chips (`<a class="tag-chip">`) had `padding: 3px 7px` with no touch rule — ~22px tall. Back link and `← newer` / `older →` links were similarly small. Added `@media (pointer: coarse)` to bring all three to `min-height: 44px`.

### `blog/index.astro` — post title links

The tag filter buttons already had a coarse-pointer rule from a previous PR. The post title `<a>` links inside `.post-row` did not. Added `min-height: 44px; display: inline-flex; align-items: center` on coarse pointer.

### `Terminal.astro` — title bar overflow

`pasha@portfolio:~/blog/post` at 14px IBM Plex Mono is borderline on 320px devices. Added `overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0` to `.terminal-title` (and `min-width: 0` to its flex parent) so long paths truncate gracefully rather than overflowing.

## Regression checklist
- [x] `npm run build` passes clean
- [x] `/`, `/blog`, `/blog/building-mycel` all render correctly at desktop viewport
- [x] Desktop interaction unchanged (auto-focus, no tap hint visible, link sizes unchanged)
- [x] No new JS introduced beyond the auto-focus guard and tap hint hide-on-focus